### PR TITLE
fix(package.json): adds missing "type": "module" declaration in package.json

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+const jestConfig = {
   bail: true,
   collectCoverageFrom: ['src/index.ts'],
   globals: {
@@ -14,3 +14,10 @@ module.exports = {
   transform: { '^.+\\.(ts|tsx|js|jsx)?$': 'ts-jest' },
   transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(ts|tsx)$'],
 }
+
+// Why was this changed from CJS to ESM?
+// When updating the package.json so Node would understand to execute
+// the code as ESM not CJS using "type": "module" the test suite broke
+// This was due to Node wanting to execute everything as ESM. Changing
+// the configuration to be exported as ESM solved the issue.
+export default jestConfig

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "unified"
   ],
   "main": "dist/index.js",
+  "type": "module",
   "typings": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Without this declaration Node assumes that CJS instead of ESM 

- [here for more](https://stackoverflow.com/questions/61670459/nodejs-must-use-import-to-load-es-module)